### PR TITLE
Connect minesweeper to grid structure

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,13 +1,14 @@
 use bindings::Windows::{
     Foundation::Numerics::{Vector2, Vector3},
     UI::Colors,
-    UI::Composition::{Compositor, ContainerVisual},
+    UI::Composition::{Compositor, ContainerVisual, SpriteVisual},
 };
 
 #[derive(Clone)]
 pub struct Grid {
     compositor: Compositor,
     root: ContainerVisual,
+    tiles: Vec<SpriteVisual>,
 
     tile_size: Vector2,
     margin: Vector2,
@@ -25,13 +26,17 @@ impl Grid {
         Ok(Self {
             compositor: compositor,
             root: root,
+            tiles: Vec::new(),
+
             tile_size: tile_size.clone(),
             margin: margin.clone(),
         })
     }
 
-    pub fn draw(&self) -> windows::Result<()> {
+    pub fn draw(&mut self) -> windows::Result<()> {
         let children = self.root.Children()?;
+        children.RemoveAll()?;
+        self.tiles.clear();
 
         self.root.SetSize(
             (&self.tile_size + Vector2::new(2.5, 2.5)) * Vector2::new(16.0 as f32, 16.0 as f32),
@@ -56,6 +61,7 @@ impl Grid {
                 )?;
 
                 children.InsertAtTop(&visual)?;
+                self.tiles.push(visual);
             }
         }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -4,6 +4,7 @@ use bindings::Windows::{
     UI::Composition::{Compositor, ContainerVisual},
 };
 
+#[derive(Clone)]
 pub struct Grid {
     compositor: Compositor,
     root: ContainerVisual,

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -31,7 +31,6 @@ impl Grid {
 
     pub fn draw(&self) -> windows::Result<()> {
         let children = self.root.Children()?;
-        let color_brush = self.compositor.CreateColorBrushWithColor(Colors::Red()?)?;
 
         self.root.SetSize(
             (&self.tile_size + Vector2::new(2.5, 2.5)) * Vector2::new(16.0 as f32, 16.0 as f32),
@@ -41,7 +40,6 @@ impl Grid {
             for y in 0..8 {
                 let visual = self.compositor.CreateSpriteVisual()?;
                 visual.SetSize(&self.tile_size)?;
-                visual.SetBrush(&color_brush)?;
                 visual.SetCenterPoint(Vector3::new(
                     self.tile_size.X / 2.0,
                     self.tile_size.Y / 2.0,
@@ -55,6 +53,7 @@ impl Grid {
                             0.0,
                         ) * Vector3::new(x as f32, y as f32, 0.0)),
                 )?;
+
                 children.InsertAtTop(&visual)?;
             }
         }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -71,4 +71,8 @@ impl Grid {
     pub fn root(&self) -> &ContainerVisual {
         &self.root
     }
+
+    pub fn tiles_iter(&self) -> impl std::iter::Iterator<Item = &SpriteVisual> {
+        self.tiles.iter()
+    }
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -5,22 +5,31 @@ use bindings::Windows::{
 };
 
 pub struct Grid {
-    container_visual: ContainerVisual,
     compositor: Compositor,
+    root: ContainerVisual,
+
     tile_size: Vector2,
 }
 
 impl Grid {
-    pub fn new(container_visual: &ContainerVisual, tile_size: Vector2) -> windows::Result<Self> {
+    pub fn new(compositor: &Compositor, tile_size: Vector2) -> windows::Result<Self> {
+        let compositor = compositor.clone();
+        let root = compositor.CreateContainerVisual()?;
+
         Ok(Self {
-            container_visual: container_visual.clone(),
-            compositor: container_visual.Compositor()?.clone(),
-            tile_size: tile_size,
+            compositor: compositor,
+            root: root,
+            tile_size: tile_size.clone(),
         })
     }
 
     pub fn draw(&self) -> windows::Result<()> {
+        let children = self.root.Children()?;
         let color_brush = self.compositor.CreateColorBrushWithColor(Colors::Red()?)?;
+
+        self.root.SetSize(
+            (&self.tile_size + Vector2::new(2.5, 2.5)) * Vector2::new(16.0 as f32, 16.0 as f32),
+        )?;
 
         for x in 0..8 {
             for y in 0..8 {
@@ -32,7 +41,7 @@ impl Grid {
                     Vector3::new(1.25, 1.25, 0.0)
                         + (Vector3::new(27.5, 27.5, 27.5) * Vector3::new(x as f32, y as f32, 0.0)),
                 )?;
-                self.container_visual.Children()?.InsertAtTop(&visual)?;
+                children.InsertAtTop(&visual)?;
             }
         }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -60,4 +60,8 @@ impl Grid {
 
         Ok(())
     }
+
+    pub fn root(&self) -> &ContainerVisual {
+        &self.root
+    }
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -9,10 +9,15 @@ pub struct Grid {
     root: ContainerVisual,
 
     tile_size: Vector2,
+    margin: Vector2,
 }
 
 impl Grid {
-    pub fn new(compositor: &Compositor, tile_size: Vector2) -> windows::Result<Self> {
+    pub fn new(
+        compositor: &Compositor,
+        tile_size: Vector2,
+        margin: Vector2,
+    ) -> windows::Result<Self> {
         let compositor = compositor.clone();
         let root = compositor.CreateContainerVisual()?;
 
@@ -20,6 +25,7 @@ impl Grid {
             compositor: compositor,
             root: root,
             tile_size: tile_size.clone(),
+            margin: margin.clone(),
         })
     }
 
@@ -34,12 +40,20 @@ impl Grid {
         for x in 0..8 {
             for y in 0..8 {
                 let visual = self.compositor.CreateSpriteVisual()?;
-                visual.SetSize(Vector2::new(25.0, 25.0))?;
+                visual.SetSize(&self.tile_size)?;
                 visual.SetBrush(&color_brush)?;
-                visual.SetCenterPoint(Vector3::new(12.5, 12.5, 0.0))?;
+                visual.SetCenterPoint(Vector3::new(
+                    self.tile_size.X / 2.0,
+                    self.tile_size.Y / 2.0,
+                    0.0,
+                ))?;
                 visual.SetOffset(
-                    Vector3::new(1.25, 1.25, 0.0)
-                        + (Vector3::new(27.5, 27.5, 27.5) * Vector3::new(x as f32, y as f32, 0.0)),
+                    Vector3::new(self.margin.X / 2.0, self.margin.Y / 2.0, 0.0)
+                        + (Vector3::new(
+                            self.tile_size.X + self.margin.X,
+                            self.tile_size.Y + self.margin.Y,
+                            0.0,
+                        ) * Vector3::new(x as f32, y as f32, 0.0)),
                 )?;
                 children.InsertAtTop(&visual)?;
             }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -7,21 +7,15 @@ use bindings::Windows::{
 pub struct Grid {
     container_visual: ContainerVisual,
     compositor: Compositor,
-    width: u32,
-    height: u32,
+    tile_size: Vector2,
 }
 
 impl Grid {
-    pub fn new(
-        container_visual: &ContainerVisual,
-        width: u32,
-        height: u32,
-    ) -> windows::Result<Self> {
+    pub fn new(container_visual: &ContainerVisual, tile_size: Vector2) -> windows::Result<Self> {
         Ok(Self {
             container_visual: container_visual.clone(),
             compositor: container_visual.Compositor()?.clone(),
-            width,
-            height,
+            tile_size: tile_size,
         })
     }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -15,8 +15,8 @@ pub struct Grid {
 impl Grid {
     pub fn new(
         compositor: &Compositor,
-        tile_size: Vector2,
-        margin: Vector2,
+        tile_size: &Vector2,
+        margin: &Vector2,
     ) -> windows::Result<Self> {
         let compositor = compositor.clone();
         let root = compositor.CreateContainerVisual()?;

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -24,8 +24,8 @@ impl Grid {
         let root = compositor.CreateContainerVisual()?;
 
         Ok(Self {
-            compositor: compositor,
-            root: root,
+            compositor,
+            root,
             tiles: Vec::new(),
 
             tile_size: tile_size.clone(),

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -48,7 +48,7 @@ impl GUI {
         self.game_board.draw()?;
 
         let color_brush = self.compositor.CreateColorBrushWithColor(Colors::Blue()?)?;
-        
+
         for tile in self.game_board.tiles_iter() {
             tile.SetBrush(&color_brush)?;
         }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -34,9 +34,9 @@ impl GUI {
         root.Children()?.InsertAtTop(game_board_visual)?;
 
         let mut result = Self {
-            compositor: compositor,
+            compositor,
             window_size: window_size.clone(),
-            game_board: game_board,
+            game_board,
         };
 
         result.reset()?;

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -6,6 +6,7 @@ use bindings::Windows::{
     UI::Composition::{CompositionBorderMode, Compositor, ContainerVisual},
 };
 
+#[derive(Clone)]
 pub struct GUI {
     compositor: Compositor,
     window_size: Vector2,

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -33,17 +33,25 @@ impl GUI {
         game_board_visual.SetAnchorPoint(Vector2::new(0.5, 0.5))?;
         root.Children()?.InsertAtTop(game_board_visual)?;
 
-        let result = Self {
+        let mut result = Self {
             compositor: compositor,
             window_size: window_size.clone(),
             game_board: game_board,
         };
 
+        result.reset()?;
+
         Ok(result)
     }
 
-    pub fn draw_grid(&self) -> windows::Result<()> {
+    pub fn reset(&mut self) -> windows::Result<()> {
         self.game_board.draw()?;
+
+        let color_brush = self.compositor.CreateColorBrushWithColor(Colors::Blue()?)?;
+        
+        for tile in self.game_board.tiles_iter() {
+            tile.SetBrush(&color_brush)?;
+        }
 
         Ok(())
     }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,0 +1,43 @@
+use crate::grid::Grid;
+
+use bindings::Windows::{
+    Foundation::Numerics::{Vector2, Vector3},
+    UI::Colors,
+    UI::Composition::{CompositionBorderMode, Compositor, ContainerVisual},
+};
+
+pub struct GUI {
+    compositor: Compositor,
+    window_size: Vector2,
+
+    game_board: Grid,
+}
+
+impl GUI {
+    pub fn new(container_visual: &ContainerVisual, window_size: &Vector2) -> windows::Result<Self> {
+        let compositor = container_visual.Compositor()?;
+        let root = compositor.CreateSpriteVisual()?;
+
+        root.SetRelativeSizeAdjustment(Vector2::new(1.0, 1.0))?;
+        root.SetBrush(compositor.CreateColorBrushWithColor(Colors::White()?)?)?;
+        root.SetBorderMode(CompositionBorderMode::Hard)?;
+        container_visual.Children()?.InsertAtTop(&root)?;
+
+        let tile_size = Vector2::new(25.0, 25.0);
+        let margin = Vector2::new(2.5, 2.5);
+        let game_board = Grid::new(&compositor, &tile_size, &margin)?;
+
+        let game_board_visual = game_board.root();
+        game_board_visual.SetRelativeOffsetAdjustment(Vector3::new(0.5, 0.5, 0.0))?;
+        game_board_visual.SetAnchorPoint(Vector2::new(0.5, 0.5))?;
+        root.Children()?.InsertAtTop(game_board_visual)?;
+
+        let result = Self {
+            compositor: compositor,
+            window_size: window_size.clone(),
+            game_board: game_board,
+        };
+
+        Ok(result)
+    }
+}

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -40,4 +40,10 @@ impl GUI {
 
         Ok(result)
     }
+
+    pub fn draw_grid(&self) -> windows::Result<()> {
+        self.game_board.draw()?;
+
+        Ok(())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,8 @@ fn run() -> windows::Result<()> {
     let game = Minesweeper::new(
         game_board_size.Width as u32,
         game_board_size.Height as u32,
-        99, &gui,
+        99,
+        &gui,
     );
 
     event_loop.run(move |event, _, control_flow| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,6 @@ use windows::Interface;
 fn create_dispatcher() -> DispatcherQueueController {
     // We need a DispatcherQueue on our thread to properly create a Compositor. Note that since
     // we aren't pumping messages, the Compositor won't commit. This is fine for the test for now.
-
     let options = DispatcherQueueOptions {
         dwSize: std::mem::size_of::<DispatcherQueueOptions>() as u32,
         threadType: DQTYPE_THREAD_CURRENT,
@@ -57,7 +56,6 @@ fn run() -> windows::Result<()> {
     };
 
     let compositor_desktop: ICompositorDesktopInterop = compositor.cast()?;
-
     let target = unsafe {
         compositor_desktop.CreateDesktopWindowTarget(HWND(window_handle as isize), false)?
     };
@@ -67,22 +65,23 @@ fn run() -> windows::Result<()> {
     container_visual.SetRelativeSizeAdjustment(Vector2 { X: 1.0, Y: 1.0 })?;
     target.SetRoot(&container_visual)?;
 
-    // Create grid.
+    // Create GUI.
     let window_size = Vector2::new(
         window.inner_size().width as f32,
         window.inner_size().height as f32,
     );
+    let gui = GUI::new(&container_visual, &window_size)?;
+
+    // Create Minesweeper game.
     let game_board_size = SizeInt32 {
         Width: 30,
         Height: 16,
     };
-    let _game = Minesweeper::new(
+    let game = Minesweeper::new(
         game_board_size.Width as u32,
         game_board_size.Height as u32,
-        99,
+        99, &gui,
     );
-    let gui = GUI::new(&container_visual, &window_size)?;
-    gui.draw_grid()?;
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 mod grid;
+mod gui;
 mod minesweeper;
 
+use gui::GUI;
 use minesweeper::Minesweeper;
 
 use winit::{
@@ -66,17 +68,21 @@ fn run() -> windows::Result<()> {
     target.SetRoot(&container_visual)?;
 
     // Create grid.
-    let window_size = window.inner_size();
+    let window_size = Vector2::new(
+        window.inner_size().width as f32,
+        window.inner_size().height as f32,
+    );
     let game_board_size = SizeInt32 {
         Width: 30,
         Height: 16,
     };
-    let game = Minesweeper::new(
+    let _game = Minesweeper::new(
         game_board_size.Width as u32,
         game_board_size.Height as u32,
         99,
     );
-    game.show_with_mine_count();
+    let gui = GUI::new(&container_visual, &window_size)?;
+    gui.draw_grid()?;
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;

--- a/src/minesweeper.rs
+++ b/src/minesweeper.rs
@@ -1,3 +1,5 @@
+use crate::gui::GUI;
+
 use rand::Rng;
 
 #[derive(Clone)]
@@ -15,10 +17,12 @@ pub struct Minesweeper {
     mines: Vec<bool>,
     num_mines: i32,
     mine_states: Vec<MineState>,
+
+    gui: GUI,
 }
 
 impl Minesweeper {
-    pub fn new(width: u32, height: u32, num_mines: i32) -> Self {
+    pub fn new(width: u32, height: u32, num_mines: i32, gui: &GUI) -> Self {
         let board_size = (width * height) as usize;
 
         let mut result = Self {
@@ -28,6 +32,8 @@ impl Minesweeper {
             mines: vec![false; board_size],
             num_mines: num_mines,
             mine_states: vec![MineState::Empty; board_size],
+
+            gui: gui.clone(),
         };
 
         result.start();

--- a/src/minesweeper.rs
+++ b/src/minesweeper.rs
@@ -47,6 +47,8 @@ impl Minesweeper {
         }
 
         self.generate_mines();
+
+        self.gui.reset();
     }
 
     fn generate_mines(&mut self) {

--- a/src/minesweeper.rs
+++ b/src/minesweeper.rs
@@ -26,11 +26,11 @@ impl Minesweeper {
         let board_size = (width * height) as usize;
 
         let mut result = Self {
-            width: width,
-            height: height,
+            width,
+            height,
 
             mines: vec![false; board_size],
-            num_mines: num_mines,
+            num_mines,
             mine_states: vec![MineState::Empty; board_size],
 
             gui: gui.clone(),


### PR DESCRIPTION
This revision includes:
- Connect minesweeper to grid structure (Resolves #10)
  - Create struct 'GUI' and some functions
    - root
    - draw_grid
    - tiles_iter